### PR TITLE
update URLs for nhl66

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -22,7 +22,7 @@
         <icon>resources/media/icon.png</icon>
         <fanart>resources/media/fanart.jpg</fanart>
     </assets>
-    <website>https://nhl66.ir/</website>
+    <website>https://nhl24all.ir/</website>
     <source>https://github.com/tekbec/plugin.video.nhl66</source>
   </extension>
 </addon>

--- a/resources/lib/platforms/nhl66/consts.py
+++ b/resources/lib/platforms/nhl66/consts.py
@@ -1,7 +1,7 @@
 from .team import Team
 
 # API
-API_BASE_URL   = 'https://api.nhl66.ir'
+API_BASE_URL   = 'https://api.nhl24all.ir'
 STATESHOT_PATH = '/api/sport/stateshot'
 PREMIUM_ACCOUNT_API_BASE_URL = 'https://account24network.com'
 SIGNATURE_PATH               = '/api/profile/generate_entitlement_signature'

--- a/resources/lib/run_service.py
+++ b/resources/lib/run_service.py
@@ -42,7 +42,7 @@ ADDON_ICON = ADDON_DATA.getAddonInfo('icon')
 CACHE = {}
 CACHE_SIZE = 20
 USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36'
-NHL66_ESPN_CYPER_BASE_URL = 'https://api.nhl66.ir/api/get_cypher/espn'
+NHL66_ESPN_CYPER_BASE_URL = 'https://api.nhl24all.ir/api/get_cypher/espn'
 
 class RequestsHandler(BaseHTTPRequestHandler):
 


### PR DESCRIPTION
The old nhl66 URLs are no longer working. This PR updates these references to use nhl24all URLs